### PR TITLE
Added serialized size to Image and Media (Issue #5)

### DIFF
--- a/src/main/java/com/tenor/android/core/model/ContentFilter.java
+++ b/src/main/java/com/tenor/android/core/model/ContentFilter.java
@@ -1,0 +1,5 @@
+package com.tenor.android.core.model;
+
+public enum  ContentFilter {
+    high, medium, low, off
+}

--- a/src/main/java/com/tenor/android/core/model/impl/Image.java
+++ b/src/main/java/com/tenor/android/core/model/impl/Image.java
@@ -15,6 +15,9 @@ public class Image implements Serializable {
     private static final long serialVersionUID = -8616498739266612929L;
     private String url;
 
+    @SerializedName("size")
+    private long size;
+
     @SerializedName("dims")
     private int[] dimensions;
 
@@ -25,6 +28,7 @@ public class Image implements Serializable {
     public String getUrl() {
         return StringConstant.getOrEmpty(url);
     }
+
 
     public int getWidth() {
         return dimensions != null && dimensions.length == 2 ? dimensions[0] : -1;
@@ -41,5 +45,12 @@ public class Image implements Serializable {
     public float getAspectRatio() {
         final float aspectRatio = (float) getWidth() / getHeight();
         return aspectRatio >= 0.01f && aspectRatio <= 5.01f ? aspectRatio : 1.778f;
+    }
+
+    /**
+     * @return size of this {@link Image} or -1 if it doesn't exist
+     */
+    public long getSize() {
+        return size != 0 ? size : -1;
     }
 }

--- a/src/main/java/com/tenor/android/core/model/impl/Media.java
+++ b/src/main/java/com/tenor/android/core/model/impl/Media.java
@@ -11,6 +11,7 @@ public class Media extends Image {
     private static final long serialVersionUID = -8616498739266612929L;
     private String preview;
     private double duration;
+    private long size;
 
     /**
      * @return url of a static image preview
@@ -25,5 +26,12 @@ public class Media extends Image {
      */
     public double getDuration() {
         return duration;
+    }
+
+    /**
+     * @return size of this {@link Image} or -1 if it doesn't exist
+     */
+    public long getSize() {
+        return size != 0 ? size : -1;
     }
 }

--- a/src/main/java/com/tenor/android/core/network/ApiClient.java
+++ b/src/main/java/com/tenor/android/core/network/ApiClient.java
@@ -11,6 +11,7 @@ import com.tenor.android.core.constant.ScreenDensity;
 import com.tenor.android.core.constant.StringConstant;
 import com.tenor.android.core.constant.ViewAction;
 import com.tenor.android.core.measurable.MeasurableViewHolderEvent;
+import com.tenor.android.core.model.ContentFilter;
 import com.tenor.android.core.model.impl.Result;
 import com.tenor.android.core.response.WeakRefCallback;
 import com.tenor.android.core.response.impl.AnonIdResponse;
@@ -98,6 +99,18 @@ public class ApiClient {
      * content delivery experience
      */
     public static Map<String, String> getServiceIds(@NonNull final Context context) {
+        return getServiceIds(context, ContentFilter.off);
+    }
+
+    /**
+     * Get service ids that can delivery a more accurate and better experience
+     * Allows for content filtering
+     *
+     * @return a {@link Map} with {@code key} (API Key), {@code anon_id},
+     * {@code aaid} (Android Advertise Id) and {@code locale } for authentication and better
+     * content delivery experience
+     */
+    public static Map<String, String> getServiceIds(@NonNull final Context context, @NonNull final ContentFilter contentFilter) {
         final ArrayMap<String, String> map = new ArrayMap<>(4);
 
         // API Key
@@ -110,6 +123,7 @@ public class ApiClient {
          * 2. `aaid`, Android Advertise Id, is also used in case "keyboardid" or "anon_id" mutates
          * 3. `locale` is used to deliver curated language/regional specific contents to users
          * 4. `screen_density` is used to optimize the content size to the device
+         * 5. 'contentfilter' is used to specify the content safety filter level
          */
         final String id = AbstractSessionUtils.getAnonId(context);
         map.put(id.length() <= 20 ? "keyboardid" : "anon_id", id);
@@ -119,6 +133,7 @@ public class ApiClient {
         map.put("aaid", AbstractSessionUtils.getAndroidAdvertiseId(context));
         map.put("locale", AbstractLocaleUtils.getCurrentLocaleName(context));
         map.put("screen_density", ScreenDensity.get(context));
+        map.put("contentfilter", contentFilter.name());
         return map;
     }
 


### PR DESCRIPTION
In reference to issue #5 (link https://github.com/Tenor-Inc/tenor-android-core/issues/5) we listened to the customer's feedback and added the option to read the size parameter by serializing it and creating a getter.